### PR TITLE
OPENEUROPA-2164: Fix removal of inline entity meta

### DIFF
--- a/emr.module
+++ b/emr.module
@@ -78,24 +78,5 @@ function emr_entity_delete(EntityInterface $entity) {
 
   /** @var \Drupal\emr\EntityMetaStorageInterface $storage */
   $storage = \Drupal::entityTypeManager()->getStorage('entity_meta');
-  $meta_entities = $storage->getRelatedMetaEntities($entity);
-  foreach ($meta_entities as $meta_entity) {
-    $meta_entity->delete();
-  }
-
-  $entity_meta_relation_storage = \Drupal::entityTypeManager()->getStorage('entity_meta_relation');
-  $entity_meta_relation_content_field = $entity_type->get('entity_meta_relation_content_field');
-
-  $ids = $entity_meta_relation_storage->getQuery()
-    ->condition("{$entity_meta_relation_content_field}.target_id", $entity->id())
-    ->execute();
-
-  if (!$ids) {
-    return;
-  }
-
-  $entity_meta_relations = $entity_meta_relation_storage->loadMultiple($ids);
-  foreach ($entity_meta_relations as $entity_meta_relation) {
-    $entity_meta_relation->delete();
-  }
+  $storage->deleteAllRelatedMetaEntities($entity);
 }

--- a/src/Entity/EntityMetaRelation.php
+++ b/src/Entity/EntityMetaRelation.php
@@ -19,6 +19,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *   bundle_label = @Translation("Entity Meta Relation type"),
  *   handlers = {
  *     "list_builder" = "Drupal\emr\EntityMetaRelationListBuilder",
+ *     "storage" = "Drupal\emr\EntityMetaRelationStorage",
  *     "views_data" = "Drupal\views\EntityViewsData",
  *     "form" = {
  *       "add" = "Drupal\emr\Form\EntityMetaRelationForm",

--- a/src/EntityMetaRelationStorage.php
+++ b/src/EntityMetaRelationStorage.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\emr;
+
+use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
+use Drupal\emr\Entity\EntityMetaRelationInterface;
+
+/**
+ * Storage handler for the entity meta relation entities.
+ */
+class EntityMetaRelationStorage extends SqlContentEntityStorage implements EntityMetaRelationStorageInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function revisionIds(EntityMetaRelationInterface $entity_meta_relation): array {
+    return $this->database->query(
+      'SELECT revision_id FROM {' . $this->getRevisionTable() . '} WHERE id=:id ORDER BY revision_id',
+      [':id' => $entity_meta_relation->id()]
+    )->fetchCol();
+  }
+
+}

--- a/src/EntityMetaRelationStorageInterface.php
+++ b/src/EntityMetaRelationStorageInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\emr;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\emr\Entity\EntityMetaRelationInterface;
+
+/**
+ * Interface for the storage handler of EntityMetaRelation entities.
+ */
+interface EntityMetaRelationStorageInterface extends EntityStorageInterface {
+
+  /**
+   * Gets a list of revision IDs for a specific entity meta relation.
+   *
+   * @param \Drupal\emr\Entity\EntityMetaRelationInterface $entity_meta_relation
+   *   The entity meta relation.
+   *
+   * @return int[]
+   *   The revision IDs (in ascending order).
+   */
+  public function revisionIds(EntityMetaRelationInterface $entity_meta_relation): array;
+
+}

--- a/src/EntityMetaStorage.php
+++ b/src/EntityMetaStorage.php
@@ -104,11 +104,11 @@ class EntityMetaStorage extends SqlContentEntityStorage implements EntityMetaSto
     }
 
     $revision_id = key($ids);
-    /** @var \Drupal\Core\Entity\RevisionableInterface $revision */
-    $revision = $entity_meta_relation_storage->loadRevision($revision_id);
+    /** @var \Drupal\Core\Entity\RevisionableInterface $entity_meta_relation */
+    $entity_meta_relation = $entity_meta_relation_storage->loadRevision($revision_id);
 
     // Load all the revision IDs of this entity meta relation.
-    $revision_ids = $entity_meta_relation_storage->revisionIds($revision);
+    $revision_ids = $entity_meta_relation_storage->revisionIds($entity_meta_relation);
 
     // Keep track of the last revision ID because this is the one we want
     // to delete.

--- a/src/EntityMetaStorageInterface.php
+++ b/src/EntityMetaStorageInterface.php
@@ -3,12 +3,13 @@
 namespace Drupal\emr;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\emr\Entity\EntityMetaInterface;
 
 /**
  * Interface for the storage handler of EntityMeta entities.
  */
-interface EntityMetaStorageInterface {
+interface EntityMetaStorageInterface extends EntityStorageInterface {
 
   /**
    * Updates the related EntityMeta entities of a given entity.
@@ -57,6 +58,41 @@ interface EntityMetaStorageInterface {
    *   The related entities.
    */
   public function getRelatedContentEntities(EntityMetaInterface $entity, string $entity_type): array;
+
+  /**
+   * Unlinks an entity meta from a revision of a content entity.
+   *
+   * This happens when a node that uses the inline form for managing the entity
+   * meta is edited and the meta entity value is unset. This causes the last
+   * entity meta relation revision to be deleted and the previous one to be set
+   * as the default one.
+   *
+   * Attention: this method is only expected to be called after the content
+   * entity as updated its entity meta relations via
+   * self::updateEntityMetaRelated().
+   *
+   * A consequence of this happening is that if the content entity is again
+   * edited and the entity meta value is set back, a new entity meta will
+   * be created and referenced.
+   *
+   * @param \Drupal\emr\Entity\EntityMetaInterface $entity_meta
+   *   The entity meta being related.
+   * @param \Drupal\Core\Entity\ContentEntityInterface $content_entity
+   *   The content entity revision that relates.
+   *
+   * @see EntityMetaRelationInlineContentFormPluginBase::submit()
+   */
+  public function unlinkRelation(EntityMetaInterface $entity_meta, ContentEntityInterface $content_entity): void;
+
+  /**
+   * Deletes all the related meta entities.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $content_entity
+   *   The content entity.
+   *
+   * @see emr_entity_delete()
+   */
+  public function deleteAllRelatedMetaEntities(ContentEntityInterface $content_entity): void;
 
   /**
    * Returns the fields that should indicate if the entity has changed.

--- a/src/Plugin/EntityMetaRelationInlineContentFormPluginBase.php
+++ b/src/Plugin/EntityMetaRelationInlineContentFormPluginBase.php
@@ -64,7 +64,10 @@ abstract class EntityMetaRelationInlineContentFormPluginBase extends EntityMetaR
     $entity->setHostEntity($host_entity);
 
     if ($this->shouldRemoveRelation($entity)) {
-      $this->entityTypeManager->getStorage('entity_meta')->unlinkRelation($entity, $host_entity);
+      /** @var \Drupal\emr\EntityMetaStorageInterface $entity_meta_storage */
+      $entity_meta_storage = $this->entityTypeManager->getStorage('entity_meta');
+      $entity_meta_storage->unlinkRelation($entity, $host_entity);
+      return;
     }
 
     if (!$this->shouldSaveEntity($entity)) {
@@ -84,7 +87,9 @@ abstract class EntityMetaRelationInlineContentFormPluginBase extends EntityMetaR
    *   Whether it should save or not.
    */
   protected function shouldSaveEntity(EntityMetaInterface $entity): bool {
-    $change_fields = $this->entityTypeManager->getStorage('entity_meta')->getChangeFields($entity);
+    /** @var \Drupal\emr\EntityMetaStorageInterface $entity_meta_storage */
+    $entity_meta_storage = $this->entityTypeManager->getStorage('entity_meta');
+    $change_fields = $entity_meta_storage->getChangeFields($entity);
     foreach ($change_fields as $field) {
       if (!$entity->get($field)->isEmpty()) {
         return TRUE;
@@ -94,8 +99,22 @@ abstract class EntityMetaRelationInlineContentFormPluginBase extends EntityMetaR
     return FALSE;
   }
 
+  /**
+   * Checks whether the relation to this content entity should be removed.
+   *
+   * In case none of the "change" fields have values, the entity meta should
+   * be unlinked from this revision of the content entity.
+   *
+   * @param \Drupal\emr\Entity\EntityMetaInterface $entity
+   *   The entity meta entity.
+   *
+   * @return bool
+   *   Whether it should remove it or not.
+   */
   protected function shouldRemoveRelation(EntityMetaInterface $entity): bool {
-    $change_fields = $this->entityTypeManager->getStorage('entity_meta')->getChangeFields($entity);
+    /** @var \Drupal\emr\EntityMetaStorageInterface $entity_meta_storage */
+    $entity_meta_storage = $this->entityTypeManager->getStorage('entity_meta');
+    $change_fields = $entity_meta_storage->getChangeFields($entity);
     $remove = TRUE;
 
     foreach ($change_fields as $field) {


### PR DESCRIPTION
Fixing the inline entity meta removal. When editing a node, it was not possible to unset the value of a related meta. Now it will remove the last relation and if adding back meta values, it will create a new meta. The content entity still references correct meta values at the respective revisions.