### PR TITLE
OPENEUROPA-2258: Use PHP 7.2 in drone and docker image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 
 services:
   web:
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment:
       - DOCUMENT_ROOT=/test/entity_meta_relation
   mysql:
@@ -15,7 +15,7 @@ services:
 pipeline:
   composer-install-lowest:
     group: prepare
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     volumes:
       - /cache:/cache
     commands:
@@ -29,7 +29,7 @@ pipeline:
 
   composer-install-highest:
     group: prepare
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     volumes:
       - /cache:/cache
     commands:
@@ -39,25 +39,25 @@ pipeline:
         COMPOSER_BOUNDARY: highest
 
   site-install:
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
       - ./vendor/bin/run drupal:site-install
 
   grumphp:
     group: test
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
       - ./vendor/bin/grumphp run
 
   phpunit:
     group: test
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
       - ./vendor/bin/phpunit
 
   behat:
     group: test
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
       - ./vendor/bin/behat --strict
 
@@ -65,3 +65,7 @@ matrix:
   COMPOSER_BOUNDARY:
   - lowest
   - highest
+  PHP_VERSION:
+    - 7.1
+    - 7.2
+

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "drupal/config_devel": "~1.2",
         "drupal/drupal-extension": "~4.0",
         "drush/drush": "~9.0@stable",
+        "guzzlehttp/guzzle": "~6.3",
         "openeuropa/code-review": "~1.0.0-beta3",
         "openeuropa/drupal-core-require-dev": "^8.7",
         "openeuropa/task-runner": "~1.0.0-beta5",
@@ -28,7 +29,8 @@
     "_readme": [
         "We explicitly require consolidation/robo to allow lower 'composer update --prefer-lowest' to complete successfully.",
         "We explicitly require consolidation/annotated-command to allow lower 'composer update --prefer-lowest' to complete successfully.",
-        "symfony/browser-kit is explicitly required to make phpunit tests pass for 'composer update --prefer-lowest'."
+        "We explicitly require guzzlehttp/guzzle to make phpunit tests pass for 'composer update --prefer-lowest' to complete successfully.",
+        "We explicitly require symfony/browser-kit to make phpunit tests pass for 'composer update --prefer-lowest'."
     ],
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
@@ -62,9 +64,6 @@
         }
     },
     "config": {
-        "sort-packages": true,
-        "platform": {
-            "php": "7.1.9"
-        }
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
## OPENEUROPA-2258

### Description

Use PHP 7.2 in drone and docker image.

### Change log

- Added: PHP 7.2 usage in docker-compose and drone.