### PR TITLE
Drupal 9 compatibility fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -77,5 +77,4 @@ matrix:
     - lowest
     - highest
   PHP_VERSION:
-    - 7.2
     - 7.3

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # Entity Meta Relation
 
-The Entity meta relation module allows to associate extra information stored in independent entities (meta entities) to content (host) entities. This avoids the need to store this information as a content entity field and pollute the content entity keeping metadata information that controls specific entity behaviour outside of its main storage. 
+The Entity meta relation module allows to associate extra information stored in independent entities (meta entities) to content (host) entities. This avoids the need to store this information as a content entity field and pollute the content entity keeping metadata information that controls specific entity behaviour outside of its main storage.
 ​
 ## Content Structure
 
 * `EntityMeta` entities are regular content entities that can be fieldable and revisionable.
 * `EntityMetaRelation` entities hold the relationship between content entities (such as nodes) and their `EntityMeta` entities. The relations are held directly to content entity revisions and `EntityMeta` revisions allowing to follow new revisions in both directions.
 ​
-`EntityMeta` entities require a defined relation between themselves and content (host) entities. Moreover, each `EntityMeta` bundle is made applicable to each content entity bundle through configuration defined in 3rd party settings. The required configuration can be set automatically by using *EntityMetaRelationInstaller* service. An example of its usage can be seen in *entity_meta_example_install*. 
+`EntityMeta` entities require a defined relation between themselves and content (host) entities. Moreover, each `EntityMeta` bundle is made applicable to each content entity bundle through configuration defined in 3rd party settings. The required configuration can be set automatically by using *EntityMetaRelationInstaller* service. An example of its usage can be seen in *entity_meta_example_install*.
 ​
 The `entity_meta_example` module contain several example plugins that are used for tests but can be used as references.
 
 ## Support for new content entities
 
-Entity meta relations can be used with any content entity. 
+Entity meta relations can be used with any content entity.
 
 However, the `emr_node` module already provides support for `Node` entities. It can be used to understand how to provide support for other content entities.
 ​
-* A new `EntityMetaRelation` bundle should be created with at least two fields: 
+* A new `EntityMetaRelation` bundle should be created with at least two fields:
   * one `EntityReferenceRevision` field that targets the (host) content entity revisions (see the `emr_node_revision` field as an example for relating to Node entities).
   * one field that targets the `EntityMeta` revisions (see the `emr_meta_revision` field as an example for relating to the `EntityMeta` entities. The storage of this field could be reused).
 * The host entity definition should be altered to include the following properties:
     - `entity_meta_relation_bundle`: Should specify the `EntityMetaRelation` bundle you created above.
     - `entity_meta_relation_content_field`: Should specify the field name that relates to the content (host) entity you created above.
     - `entity_meta_relation_meta_field`: Should specify the field name that relates to the `EntityMeta` entities you created above.
-    - `emr_content_form`: In case the content (host) entity form should be used to include a form to manipulate the related `EntityMeta` entities, this should specify the form handler class to use for this. 
+    - `emr_content_form`: In case the content (host) entity form should be used to include a form to manipulate the related `EntityMeta` entities, this should specify the form handler class to use for this.
 ​
 
 Foe more information, check `emr_node_entity_type_alter` for an example how this is done for nodes:
@@ -32,7 +32,7 @@ Foe more information, check `emr_node_entity_type_alter` for an example how this
 The following is defined:
 
 - The `EntityMetaRelation` bundle is `node_meta_relation`, and it has two fields:
-  - `emr_node_revision`: points to the `Node` entity revision 
+  - `emr_node_revision`: points to the `Node` entity revision
   - `emr_meta_revision`: points to the `EntityMeta` revision
 - The handler class `NodeFormHandler` is defined to deal with content entity form changes.
 
@@ -89,7 +89,7 @@ $entity_meta->set('field_color', 'red');
 // node is saved, the relations are created automatically.
 $entity_meta_list->attach($entity_meta);
 $node->save();
-```    
+```
 ​
 ​
 ### Adding several EntityMeta entities to content entity
@@ -123,7 +123,7 @@ $entity_metas[] = $entity_meta;
 // Set the array of entites meta entities as values.
 $entity_meta_list->set($entity_metas);
 $node->save();
-```    
+```
 ​
 ​
 ### Using an EntityMetaWrapper
@@ -156,7 +156,7 @@ $node->save();
 Please note that the `attach()` method won't do anything if there is no change
 detected in the `EntityMeta` entity.
 ​
-### Removing existing EntityMeta  
+### Removing existing EntityMeta
 
 Existing `EntityMeta` entities can be removed from the revision through the `detach()` method.
 
@@ -180,6 +180,25 @@ composer install
 A post command hook (`drupal:site-setup`) is triggered automatically after `composer install`.
 It will make sure that the necessary symlinks are properly setup in the development site.
 It will also perform token substitution in development configuration files such as `behat.yml.dist`.
+
+This will also:
+- Symlink the theme in  `./build/modules/custom/entity_meta_relation` so that it's available for the test site
+- Setup Drush and Drupal's settings using values from `./runner.yml.dist`.
+- Setup PHPUnit and Behat configuration files using values from `./runner.yml.dist`
+
+**Please note:** project files and directories are symlinked within the test site by using the
+[OpenEuropa Task Runner's Drupal project symlink](https://github.com/openeuropa/task-runner-drupal-project-symlink)
+command.
+
+If you add a new file or directory in the root of the project, you need to re-run `drupal:site-setup` in order to make
+sure they are correctly symlinked.
+
+If you don't want to re-run a full site setup for that, you can simply run:
+
+```
+$ ./vendor/bin/run drupal:symlink-project
+```
+
 ​
 * Install test site by running:
 ​
@@ -191,10 +210,10 @@ The development site web root should be available in the `build` directory.
 ​
 ### Using Docker Compose
 ​
-Alternatively, you can build a development site using [Docker](https://www.docker.com/get-docker) and 
+Alternatively, you can build a development site using [Docker](https://www.docker.com/get-docker) and
 [Docker Compose](https://docs.docker.com/compose/) with the provided configuration.
 ​
-Docker provides the necessary services and tools such as a web server and a database server to get the site running, 
+Docker provides the necessary services and tools such as a web server and a database server to get the site running,
 regardless of your local host configuration.
 ​
 #### Requirements:
@@ -206,7 +225,7 @@ regardless of your local host configuration.
 ​
 By default, Docker Compose reads two files, a `docker-compose.yml` and an optional `docker-compose.override.yml` file.
 By convention, the `docker-compose.yml` contains your base configuration and it's provided by default.
-The override file, as its name implies, can contain configuration overrides for existing services or entirely new 
+The override file, as its name implies, can contain configuration overrides for existing services or entirely new
 services.
 If a service is defined in both files, Docker Compose merges the configurations.
 ​

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -2,7 +2,7 @@ default:
   suites:
     default:
       paths:
-        - %paths.base%/tests/features
+        - "%paths.base%/tests/features"
       contexts:
         - Drupal\DrupalExtension\Context\MinkContext
         - Drupal\DrupalExtension\Context\DrupalContext

--- a/composer.json
+++ b/composer.json
@@ -6,31 +6,23 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/core": "^8.7",
+        "drupal/core": "^8.9 || ^9.1",
         "drupal/inline_entity_form": "^1.0",
         "drupal/entity_reference_revisions": "^1.6",
-        "php": ">=7.2"
+        "php": ">=7.3"
     },
     "require-dev": {
         "composer/installers": "~1.5",
-        "consolidation/robo": "~1.4",
-        "consolidation/annotated-command": "^2.8.2",
-        "drupal/core-composer-scaffold": "^8.8",
+        "drupal/core-composer-scaffold": "^8.9 || ^9.1",
         "drupal/config_devel": "~1.2",
         "drupal/drupal-extension": "~4.0",
-        "drush/drush": "~9.0@stable",
-        "guzzlehttp/guzzle": "~6.3",
-        "openeuropa/code-review": "~1.5.0",
-        "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/task-runner": "~1.0.0-beta5",
-        "phpunit/phpunit": "~6.0",
-        "symfony/browser-kit": "~3.0||~4.0"
+        "drush/drush": "~10.3",
+        "openeuropa/code-review": "~1.6",
+        "openeuropa/drupal-core-require-dev": "^8.9 || ^9.1",
+        "openeuropa/task-runner-drupal-project-symlink": "^1.0",
+        "phpspec/prophecy-phpunit": "^1 || ^2",
+        "phpunit/phpunit": "^6.5 || ^7 || ^8 || ^9"
     },
-    "_readme": [
-        "We explicitly require consolidation/robo to allow lower 'composer update --prefer-lowest' to complete successfully.",
-        "We explicitly require consolidation/annotated-command to allow lower 'composer update --prefer-lowest' to complete successfully.",
-        "We explicitly require symfony/browser-kit to make phpunit tests pass for 'composer update --prefer-lowest'."
-    ],
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",
         "post-update-cmd": "./vendor/bin/run drupal:site-setup"

--- a/composer.json
+++ b/composer.json
@@ -6,21 +6,21 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
+        "php": ">=7.3",
         "drupal/core": "^8.9 || ^9.1",
-        "drupal/inline_entity_form": "^1.0",
         "drupal/entity_reference_revisions": "^1.6",
-        "php": ">=7.3"
+        "drupal/inline_entity_form": "^1.0"
     },
     "require-dev": {
         "composer/installers": "~1.5",
         "drupal/core-composer-scaffold": "^8.9 || ^9.1",
-        "drupal/config_devel": "~1.2",
-        "drupal/drupal-extension": "~4.0",
-        "drush/drush": "~10.3",
-        "openeuropa/code-review": "~1.6",
+        "drupal/config_devel": "^1.2",
+        "drupal/drupal-extension": "^4.0",
+        "drush/drush": "^10.3",
+        "openeuropa/code-review": "^1.6",
         "openeuropa/drupal-core-require-dev": "^8.9 || ^9.1",
         "openeuropa/task-runner-drupal-project-symlink": "^1.0",
-        "phpunit/phpunit": "^6.5 || ^7 || ^8 || ^9"
+        "phpspec/prophecy-phpunit": "^1 || ^2"
     },
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",

--- a/composer.json
+++ b/composer.json
@@ -6,31 +6,22 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/core": "^8.7",
+        "drupal/core": "^8.9 || ^9.1",
         "drupal/inline_entity_form": "^1.0",
         "drupal/entity_reference_revisions": "^1.6",
-        "php": ">=7.2"
+        "php": ">=7.3"
     },
     "require-dev": {
         "composer/installers": "~1.5",
-        "consolidation/robo": "~1.4",
-        "consolidation/annotated-command": "^2.8.2",
-        "drupal/core-composer-scaffold": "^8.8",
+        "drupal/core-composer-scaffold": "^8.9 || ^9.1",
         "drupal/config_devel": "~1.2",
         "drupal/drupal-extension": "~4.0",
-        "drush/drush": "~9.0@stable",
-        "guzzlehttp/guzzle": "~6.3",
-        "openeuropa/code-review": "~1.5.0",
-        "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/task-runner": "~1.0.0-beta5",
-        "phpunit/phpunit": "~6.0",
-        "symfony/browser-kit": "~3.0||~4.0"
+        "drush/drush": "~10.3",
+        "openeuropa/code-review": "~1.6",
+        "openeuropa/drupal-core-require-dev": "^8.9 || ^9.1",
+        "openeuropa/task-runner-drupal-project-symlink": "^1.0",
+        "phpunit/phpunit": "^6.5 || ^7 || ^8 || ^9"
     },
-    "_readme": [
-        "We explicitly require consolidation/robo to allow lower 'composer update --prefer-lowest' to complete successfully.",
-        "We explicitly require consolidation/annotated-command to allow lower 'composer update --prefer-lowest' to complete successfully.",
-        "We explicitly require symfony/browser-kit to make phpunit tests pass for 'composer update --prefer-lowest'."
-    ],
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",
         "post-update-cmd": "./vendor/bin/run drupal:site-setup"

--- a/emr.info.yml
+++ b/emr.info.yml
@@ -2,7 +2,7 @@ name: Entity Meta Relation
 type: module
 description: 'Provides an entity meta relation entity and associated behaviors for relations.'
 package: Entity Meta Relation
-core: 8.x
+core_version_requirement: ^8.9 || ^9.1
 
 dependencies:
   - entity_reference_revisions:entity_reference_revisions

--- a/modules/emr_node/emr_node.info.yml
+++ b/modules/emr_node/emr_node.info.yml
@@ -2,7 +2,7 @@ name: Entity Meta Relation Node
 type: module
 description: 'Configure entity meta relations for nodes.'
 package: Entity Meta Relation
-core: 8.x
+core_version_requirement: ^8.9 || ^9.1
 
 dependencies:
   - entity_meta_relation:emr

--- a/modules/entity_meta_example/entity_meta_example.info.yml
+++ b/modules/entity_meta_example/entity_meta_example.info.yml
@@ -2,7 +2,7 @@ name: Entity Meta Example
 type: module
 description: 'Defines an example meta entity to be related with nodes'
 package: Entity Meta Relation
-core: 8.x
+core_version_requirement: ^8.9 || ^9.1
 
 dependencies:
   - entity_meta_relation:emr_node

--- a/modules/entity_meta_example/entity_meta_example.install
+++ b/modules/entity_meta_example/entity_meta_example.install
@@ -10,7 +10,10 @@ declare(strict_types = 1);
 /**
  * Implements hook_install().
  */
-function entity_meta_example_install() {
+function entity_meta_example_install($is_syncing) {
+  if ($is_syncing) {
+    return;
+  }
   /** @var \Drupal\emr\EntityMetaRelationInstaller $installer */
   $installer = \Drupal::service('emr.installer');
   $installer->installEntityMetaTypeOnContentEntityType('visual', 'node', ['entity_meta_example_ct']);

--- a/modules/entity_meta_example/modules/entity_meta_audio/entity_meta_audio.info.yml
+++ b/modules/entity_meta_example/modules/entity_meta_audio/entity_meta_audio.info.yml
@@ -2,7 +2,7 @@ name: Entity Meta Audio
 type: module
 description: 'Defines an example meta entity for audio information'
 package: Entity Meta Relation
-core: 8.x
+core_version_requirement: ^8.9 || ^9.1
 
 dependencies:
   - entity_meta_relation:emr

--- a/modules/entity_meta_example/modules/entity_meta_force/entity_meta_force.info.yml
+++ b/modules/entity_meta_example/modules/entity_meta_force/entity_meta_force.info.yml
@@ -2,7 +2,7 @@ name: Entity Meta Force
 type: module
 description: 'Defines an example meta entity for force information'
 package: Entity Meta Relation
-core: 8.x
+core_version_requirement: ^8.9 || ^9.1
 
 dependencies:
   - entity_meta_relation:emr

--- a/modules/entity_meta_example/modules/entity_meta_speed/entity_meta_speed.info.yml
+++ b/modules/entity_meta_example/modules/entity_meta_speed/entity_meta_speed.info.yml
@@ -2,7 +2,7 @@ name: Entity Meta Speed
 type: module
 description: 'Defines an example meta entity for speed information'
 package: Entity Meta Relation
-core: 8.x
+core_version_requirement: ^8.9 || ^9.1
 
 dependencies:
   - entity_meta_relation:emr_node

--- a/modules/entity_meta_example/modules/entity_meta_visual/entity_meta_visual.info.yml
+++ b/modules/entity_meta_example/modules/entity_meta_visual/entity_meta_visual.info.yml
@@ -2,7 +2,7 @@ name: Entity Meta Visual
 type: module
 description: 'Defines an example meta entity for visual information'
 package: Entity Meta Relation
-core: 8.x
+core_version_requirement: ^8.9 || ^9.1
 
 dependencies:
   - entity_meta_relation:emr_node

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="${drupal.root}/core/tests/bootstrap.php" backupGlobals="true" colors="true" >
+<phpunit bootstrap="${drupal.root}/core/tests/bootstrap.php" backupGlobals="true" colors="true" cacheResult="false">
   <php>
     <ini name="error_reporting" value="32767"/>
     <ini name="memory_limit" value="-1"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
     <env name="SIMPLETEST_DB" value="mysql://${drupal.database.user}:${drupal.database.password}@${drupal.database.host}:${drupal.database.port}/${drupal.database.name}"/>
   </php>
   <testsuites>
-    <testsuite>
+    <testsuite name="Entity meta relation tests">
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -32,7 +32,7 @@ drupal:
 
 commands:
   drupal:site-setup:
-    - { task: "symlink", from: "../../..", to: "${drupal.root}/modules/custom/emr" }
+    - { task: "run", command: "drupal:symlink-project" }
     - { task: "run", command: "drupal:drush-setup" }
     - { task: "run", command: "drupal:settings-setup" }
     - { task: "run", command: "setup:phpunit" }

--- a/src/Entity/EntityMeta.php
+++ b/src/Entity/EntityMeta.php
@@ -51,6 +51,7 @@ use Drupal\emr\Field\DefaultRevisionFieldItemList;
  *     "status" = "status"
  *   },
  *   revision_metadata_keys = {
+ *     "revision_user" = "revision_user",
  *     "revision_created" = "revision_timestamp",
  *     "revision_log_message" = "revision_log"
  *   },

--- a/src/Entity/EntityMetaRelation.php
+++ b/src/Entity/EntityMetaRelation.php
@@ -42,6 +42,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *     "uuid" = "uuid"
  *   },
  *   revision_metadata_keys = {
+ *     "revision_user" = "revision_user",
  *     "revision_created" = "revision_timestamp",
  *     "revision_log_message" = "revision_log"
  *   },

--- a/src/EntityMetaListBuilder.php
+++ b/src/EntityMetaListBuilder.php
@@ -88,7 +88,7 @@ class EntityMetaListBuilder extends EntityListBuilder {
    */
   public function buildRow(EntityInterface $entity) {
     /* @var $entity \Drupal\emr\Entity\EntityMetaInterface */
-    $row['id'] = $entity->link();
+    $row['id'] = $entity->toLink()->toString();
     $row['status'] = $entity->isEnabled() ? $this->t('Enabled') : $this->t('Disabled');
     return $row + parent::buildRow($entity);
   }

--- a/src/EntityMetaRelationListBuilder.php
+++ b/src/EntityMetaRelationListBuilder.php
@@ -87,7 +87,7 @@ class EntityMetaRelationListBuilder extends EntityListBuilder {
    */
   public function buildRow(EntityInterface $entity) {
     /* @var $entity \Drupal\emr\Entity\EntityMetaRelationInterface */
-    $row['id'] = $entity->link();
+    $row['id'] = $entity->toLink()->toString();
     return $row + parent::buildRow($entity);
   }
 

--- a/tests/Functional/EntityMetaRelationContentFormTest.php
+++ b/tests/Functional/EntityMetaRelationContentFormTest.php
@@ -94,8 +94,8 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     $this->getSession()->getPage()->fillField('Title', $label);
     $this->getSession()->getPage()->uncheckField('Published');
     $this->getSession()->getPage()->fillField('Color', 'red');
-    $this->assertFalse((boolean) $this->getSession()->getPage()->hasField('Volume'));
-    $this->assertFalse((boolean) $this->getSession()->getPage()->hasField('Gear'));
+    $this->assertFalse($this->getSession()->getPage()->hasField('Volume'));
+    $this->assertFalse($this->getSession()->getPage()->hasField('Gear'));
     $this->getSession()->getPage()->pressButton('Save');
 
     $this->getSession()->getPage()->hasContent("{$label} has been created");
@@ -110,7 +110,7 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     // Color was properly saved.
     $this->assertEquals($entity_meta->get('field_color')->value, 'red');
     // Status was properly set.
-    $this->assertFalse((boolean) $entity_meta->get('status')->value);
+    $this->assertFalse((bool) $entity_meta->get('status')->value);
     $this->assertEquals(1, $entity_meta->getRevisionId());
 
     // Change node status and color.
@@ -118,8 +118,8 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     $this->getSession()->getPage()->fillField('Title', 'Node example 2');
     $this->getSession()->getPage()->checkField('Published');
     $this->getSession()->getPage()->selectFieldOption('Color', 'green');
-    $this->assertFalse((boolean) $this->getSession()->getPage()->hasField('Volume'));
-    $this->assertFalse((boolean) $this->getSession()->getPage()->hasField('Gear'));
+    $this->assertFalse($this->getSession()->getPage()->hasField('Volume'));
+    $this->assertFalse($this->getSession()->getPage()->hasField('Gear'));
     $this->getSession()->getPage()->pressButton('Save');
     $node_updated = $this->getEntityByLabel('node', 'Node example 2');
     $entity_meta_relation_storage->resetCache();
@@ -132,7 +132,7 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     // Color was properly saved.
     $this->assertEquals($entity_meta->get('field_color')->value, 'green');
     // Status was properly changed.
-    $this->assertTrue((boolean) $entity_meta->get('status')->value);
+    $this->assertTrue((bool) $entity_meta->get('status')->value);
     // Revision changed.
     $this->assertEquals(2, $entity_meta->getRevisionId());
 
@@ -152,7 +152,7 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     // Color was kept the same.
     $this->assertEquals($entity_meta->get('field_color')->value, 'green');
     // Status was kept the same.
-    $this->assertTrue((boolean) $entity_meta->get('status')->value);
+    $this->assertTrue((bool) $entity_meta->get('status')->value);
     // Revision did not change.
     $this->assertEquals(2, $entity_meta->getRevisionId());
 
@@ -161,8 +161,8 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     $this->getSession()->getPage()->fillField('Title', 'Node example 4');
     $this->getSession()->getPage()->uncheckField('Create new revision');
     $this->getSession()->getPage()->selectFieldOption('Color', 'red');
-    $this->assertFalse((boolean) $this->getSession()->getPage()->hasField('Volume'));
-    $this->assertFalse((boolean) $this->getSession()->getPage()->hasField('Gear'));
+    $this->assertFalse($this->getSession()->getPage()->hasField('Volume'));
+    $this->assertFalse($this->getSession()->getPage()->hasField('Gear'));
     $this->getSession()->getPage()->pressButton('Save');
     $node_updated_no_revision = $this->getEntityByLabel('node', 'Node example 4');
     $entity_meta_relation_storage->resetCache();
@@ -210,7 +210,7 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     // Color was properly saved.
     $this->assertEquals($entity_meta->get('field_color')->value, 'red');
     // Status was properly set.
-    $this->assertFalse((boolean) $entity_meta->get('status')->value);
+    $this->assertFalse((bool) $entity_meta->get('status')->value);
     $this->assertEquals(1, $entity_meta->getRevisionId());
 
     // Edit the node and set the color to None.
@@ -305,15 +305,15 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
 
     // Visual was properly saved.
     $this->assertEquals($visual_meta->get('field_color')->value, 'red');
-    $this->assertFalse((boolean) $visual_meta->get('status')->value);
+    $this->assertFalse((bool) $visual_meta->get('status')->value);
 
     // Audio was properly saved.
     $this->assertEquals($audio_meta->get('field_volume')->value, 'low');
-    $this->assertFalse((boolean) $audio_meta->get('status')->value);
+    $this->assertFalse((bool) $audio_meta->get('status')->value);
 
     // Speed was properly saved.
     $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-    $this->assertFalse((boolean) $speed_meta->get('status')->value);
+    $this->assertFalse((bool) $speed_meta->get('status')->value);
 
     // Change node status and color.
     $this->drupalGet('node/' . $node->id() . '/edit');
@@ -339,15 +339,15 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
 
     // Visual was properly saved.
     $this->assertEquals($visual_meta->get('field_color')->value, 'green');
-    $this->assertTrue((boolean) $visual_meta->get('status')->value);
+    $this->assertTrue((bool) $visual_meta->get('status')->value);
 
     // Audio was properly saved.
     $this->assertEquals($audio_meta->get('field_volume')->value, 'low');
-    $this->assertTrue((boolean) $audio_meta->get('status')->value);
+    $this->assertTrue((bool) $audio_meta->get('status')->value);
 
     // Speed was properly saved.
     $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-    $this->assertTrue((boolean) $speed_meta->get('status')->value);
+    $this->assertTrue((bool) $speed_meta->get('status')->value);
 
     // Revision changed.
     $this->assertEquals(6, $visual_meta->getRevisionId());
@@ -371,13 +371,13 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
 
     // Color was kept the same.
     $this->assertEquals($visual_meta->get('field_color')->value, 'green');
-    $this->assertTrue((boolean) $visual_meta->get('status')->value);
+    $this->assertTrue((bool) $visual_meta->get('status')->value);
     // Audio was properly saved.
     $this->assertEquals($audio_meta->get('field_volume')->value, 'low');
-    $this->assertTrue((boolean) $audio_meta->get('status')->value);
+    $this->assertTrue((bool) $audio_meta->get('status')->value);
     // Speed was properly saved.
     $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-    $this->assertTrue((boolean) $speed_meta->get('status')->value);
+    $this->assertTrue((bool) $speed_meta->get('status')->value);
 
     // Revision did not change.
     $this->assertEquals(6, $visual_meta->getRevisionId());

--- a/tests/Functional/EntityMetaRelationContentFormTest.php
+++ b/tests/Functional/EntityMetaRelationContentFormTest.php
@@ -24,6 +24,11 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
   protected $adminUser;
 
   /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
    * Admin permissions for the user in the test.
    *
    * @var array
@@ -55,7 +60,7 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->adminUser = $this->drupalCreateUser($this->permissions);
@@ -89,8 +94,8 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     $this->getSession()->getPage()->fillField('Title', $label);
     $this->getSession()->getPage()->uncheckField('Published');
     $this->getSession()->getPage()->fillField('Color', 'red');
-    $this->assertFalse($this->getSession()->getPage()->hasField('Volume'));
-    $this->assertFalse($this->getSession()->getPage()->hasField('Gear'));
+    $this->assertFalse((boolean) $this->getSession()->getPage()->hasField('Volume'));
+    $this->assertFalse((boolean) $this->getSession()->getPage()->hasField('Gear'));
     $this->getSession()->getPage()->pressButton('Save');
 
     $this->getSession()->getPage()->hasContent("{$label} has been created");
@@ -105,7 +110,7 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     // Color was properly saved.
     $this->assertEquals($entity_meta->get('field_color')->value, 'red');
     // Status was properly set.
-    $this->assertFalse($entity_meta->get('status')->value);
+    $this->assertFalse((boolean) $entity_meta->get('status')->value);
     $this->assertEquals(1, $entity_meta->getRevisionId());
 
     // Change node status and color.
@@ -113,8 +118,8 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     $this->getSession()->getPage()->fillField('Title', 'Node example 2');
     $this->getSession()->getPage()->checkField('Published');
     $this->getSession()->getPage()->selectFieldOption('Color', 'green');
-    $this->assertFalse($this->getSession()->getPage()->hasField('Volume'));
-    $this->assertFalse($this->getSession()->getPage()->hasField('Gear'));
+    $this->assertFalse((boolean) $this->getSession()->getPage()->hasField('Volume'));
+    $this->assertFalse((boolean) $this->getSession()->getPage()->hasField('Gear'));
     $this->getSession()->getPage()->pressButton('Save');
     $node_updated = $this->getEntityByLabel('node', 'Node example 2');
     $entity_meta_relation_storage->resetCache();
@@ -127,7 +132,7 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     // Color was properly saved.
     $this->assertEquals($entity_meta->get('field_color')->value, 'green');
     // Status was properly changed.
-    $this->assertTrue($entity_meta->get('status')->value);
+    $this->assertTrue((boolean) $entity_meta->get('status')->value);
     // Revision changed.
     $this->assertEquals(2, $entity_meta->getRevisionId());
 
@@ -147,7 +152,7 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     // Color was kept the same.
     $this->assertEquals($entity_meta->get('field_color')->value, 'green');
     // Status was kept the same.
-    $this->assertTrue($entity_meta->get('status')->value);
+    $this->assertTrue((boolean) $entity_meta->get('status')->value);
     // Revision did not change.
     $this->assertEquals(2, $entity_meta->getRevisionId());
 
@@ -156,8 +161,8 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     $this->getSession()->getPage()->fillField('Title', 'Node example 4');
     $this->getSession()->getPage()->uncheckField('Create new revision');
     $this->getSession()->getPage()->selectFieldOption('Color', 'red');
-    $this->assertFalse($this->getSession()->getPage()->hasField('Volume'));
-    $this->assertFalse($this->getSession()->getPage()->hasField('Gear'));
+    $this->assertFalse((boolean) $this->getSession()->getPage()->hasField('Volume'));
+    $this->assertFalse((boolean) $this->getSession()->getPage()->hasField('Gear'));
     $this->getSession()->getPage()->pressButton('Save');
     $node_updated_no_revision = $this->getEntityByLabel('node', 'Node example 4');
     $entity_meta_relation_storage->resetCache();
@@ -205,7 +210,7 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
     // Color was properly saved.
     $this->assertEquals($entity_meta->get('field_color')->value, 'red');
     // Status was properly set.
-    $this->assertFalse($entity_meta->get('status')->value);
+    $this->assertFalse((boolean) $entity_meta->get('status')->value);
     $this->assertEquals(1, $entity_meta->getRevisionId());
 
     // Edit the node and set the color to None.
@@ -300,15 +305,15 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
 
     // Visual was properly saved.
     $this->assertEquals($visual_meta->get('field_color')->value, 'red');
-    $this->assertFalse($visual_meta->get('status')->value);
+    $this->assertFalse((boolean) $visual_meta->get('status')->value);
 
     // Audio was properly saved.
     $this->assertEquals($audio_meta->get('field_volume')->value, 'low');
-    $this->assertFalse($audio_meta->get('status')->value);
+    $this->assertFalse((boolean) $audio_meta->get('status')->value);
 
     // Speed was properly saved.
     $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-    $this->assertFalse($speed_meta->get('status')->value);
+    $this->assertFalse((boolean) $speed_meta->get('status')->value);
 
     // Change node status and color.
     $this->drupalGet('node/' . $node->id() . '/edit');
@@ -334,15 +339,15 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
 
     // Visual was properly saved.
     $this->assertEquals($visual_meta->get('field_color')->value, 'green');
-    $this->assertTrue($visual_meta->get('status')->value);
+    $this->assertTrue((boolean) $visual_meta->get('status')->value);
 
     // Audio was properly saved.
     $this->assertEquals($audio_meta->get('field_volume')->value, 'low');
-    $this->assertTrue($audio_meta->get('status')->value);
+    $this->assertTrue((boolean) $audio_meta->get('status')->value);
 
     // Speed was properly saved.
     $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-    $this->assertTrue($speed_meta->get('status')->value);
+    $this->assertTrue((boolean) $speed_meta->get('status')->value);
 
     // Revision changed.
     $this->assertEquals(6, $visual_meta->getRevisionId());
@@ -366,13 +371,13 @@ class EntityMetaRelationContentFormTest extends BrowserTestBase {
 
     // Color was kept the same.
     $this->assertEquals($visual_meta->get('field_color')->value, 'green');
-    $this->assertTrue($visual_meta->get('status')->value);
+    $this->assertTrue((boolean) $visual_meta->get('status')->value);
     // Audio was properly saved.
     $this->assertEquals($audio_meta->get('field_volume')->value, 'low');
-    $this->assertTrue($audio_meta->get('status')->value);
+    $this->assertTrue((boolean) $audio_meta->get('status')->value);
     // Speed was properly saved.
     $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-    $this->assertTrue($speed_meta->get('status')->value);
+    $this->assertTrue((boolean) $speed_meta->get('status')->value);
 
     // Revision did not change.
     $this->assertEquals(6, $visual_meta->getRevisionId());

--- a/tests/Kernel/EntityMetaRelationAttachByDefaultTest.php
+++ b/tests/Kernel/EntityMetaRelationAttachByDefaultTest.php
@@ -202,7 +202,7 @@ class EntityMetaRelationAttachByDefaultTest extends KernelTestBase {
     // Attach back the Force EntityMeta with new values.
     $entity_meta_force = $this->getEntityMetaList($node)->getEntityMeta('force');
     $entity_meta_force->getWrapper()->setGravity('powerful');
-    $this->assertTrue((bool) $entity_meta_force->isNew());
+    $this->assertTrue($entity_meta_force->isNew());
     $this->getEntityMetaList($node)->attach($entity_meta_force);
     $node->save();
 
@@ -238,7 +238,7 @@ class EntityMetaRelationAttachByDefaultTest extends KernelTestBase {
     $related_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertEmpty($related_meta_entities);
     $entity_meta_force = $this->getEntityMetaList($node)->getEntityMeta('force');
-    $this->assertTrue((bool) $entity_meta_force->isNew());
+    $this->assertTrue($entity_meta_force->isNew());
 
     $this->entityMetaStorage->resetCache();
     $this->nodeStorage->resetCache();
@@ -248,7 +248,7 @@ class EntityMetaRelationAttachByDefaultTest extends KernelTestBase {
     $related_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertEmpty($related_meta_entities);
     $entity_meta_force = $this->getEntityMetaList($node)->getEntityMeta('force');
-    $this->assertTrue((bool) $entity_meta_force->isNew());
+    $this->assertTrue($entity_meta_force->isNew());
   }
 
   /**

--- a/tests/Kernel/EntityMetaRelationAttachByDefaultTest.php
+++ b/tests/Kernel/EntityMetaRelationAttachByDefaultTest.php
@@ -55,7 +55,7 @@ class EntityMetaRelationAttachByDefaultTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
@@ -202,7 +202,7 @@ class EntityMetaRelationAttachByDefaultTest extends KernelTestBase {
     // Attach back the Force EntityMeta with new values.
     $entity_meta_force = $this->getEntityMetaList($node)->getEntityMeta('force');
     $entity_meta_force->getWrapper()->setGravity('powerful');
-    $this->assertTrue($entity_meta_force->isNew());
+    $this->assertTrue((boolean) $entity_meta_force->isNew());
     $this->getEntityMetaList($node)->attach($entity_meta_force);
     $node->save();
 
@@ -238,7 +238,7 @@ class EntityMetaRelationAttachByDefaultTest extends KernelTestBase {
     $related_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertEmpty($related_meta_entities);
     $entity_meta_force = $this->getEntityMetaList($node)->getEntityMeta('force');
-    $this->assertTrue($entity_meta_force->isNew());
+    $this->assertTrue((boolean) $entity_meta_force->isNew());
 
     $this->entityMetaStorage->resetCache();
     $this->nodeStorage->resetCache();
@@ -248,7 +248,7 @@ class EntityMetaRelationAttachByDefaultTest extends KernelTestBase {
     $related_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertEmpty($related_meta_entities);
     $entity_meta_force = $this->getEntityMetaList($node)->getEntityMeta('force');
-    $this->assertTrue($entity_meta_force->isNew());
+    $this->assertTrue((boolean) $entity_meta_force->isNew());
   }
 
   /**

--- a/tests/Kernel/EntityMetaRelationAttachByDefaultTest.php
+++ b/tests/Kernel/EntityMetaRelationAttachByDefaultTest.php
@@ -55,7 +55,7 @@ class EntityMetaRelationAttachByDefaultTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
@@ -202,7 +202,7 @@ class EntityMetaRelationAttachByDefaultTest extends KernelTestBase {
     // Attach back the Force EntityMeta with new values.
     $entity_meta_force = $this->getEntityMetaList($node)->getEntityMeta('force');
     $entity_meta_force->getWrapper()->setGravity('powerful');
-    $this->assertTrue($entity_meta_force->isNew());
+    $this->assertTrue((bool) $entity_meta_force->isNew());
     $this->getEntityMetaList($node)->attach($entity_meta_force);
     $node->save();
 
@@ -238,7 +238,7 @@ class EntityMetaRelationAttachByDefaultTest extends KernelTestBase {
     $related_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertEmpty($related_meta_entities);
     $entity_meta_force = $this->getEntityMetaList($node)->getEntityMeta('force');
-    $this->assertTrue($entity_meta_force->isNew());
+    $this->assertTrue((bool) $entity_meta_force->isNew());
 
     $this->entityMetaStorage->resetCache();
     $this->nodeStorage->resetCache();
@@ -248,7 +248,7 @@ class EntityMetaRelationAttachByDefaultTest extends KernelTestBase {
     $related_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertEmpty($related_meta_entities);
     $entity_meta_force = $this->getEntityMetaList($node)->getEntityMeta('force');
-    $this->assertTrue($entity_meta_force->isNew());
+    $this->assertTrue((bool) $entity_meta_force->isNew());
   }
 
   /**

--- a/tests/Kernel/EntityMetaRelationRevisionTest.php
+++ b/tests/Kernel/EntityMetaRelationRevisionTest.php
@@ -190,11 +190,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     // The meta values of the of the newly created node revisions should be the
     // same as the ones of the first revision.
     $this->assertEquals('red', $visual_meta->get('field_color')->value);
-    $this->assertNotTrue((bool) $visual_meta->get('status')->value);
+    $this->assertFalse((bool) $visual_meta->get('status')->value);
     $this->assertEquals('low', $audio_meta->get('field_volume')->value);
-    $this->assertNotTrue((bool) $audio_meta->get('status')->value);
+    $this->assertFalse((bool) $audio_meta->get('status')->value);
     $this->assertEquals('1', $speed_meta->getWrapper()->getGear());
-    $this->assertNotTrue((bool) $speed_meta->get('status')->value);
+    $this->assertFalse((bool) $speed_meta->get('status')->value);
 
     // Change again a meta value and confirm everything is normal.
     $visual_meta->set('field_color', 'blue');
@@ -210,11 +210,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
 
     $this->assertEquals($visual_meta->get('field_color')->value, 'blue');
-    $this->assertNotTrue((bool) $visual_meta->get('status')->value);
+    $this->assertFalse((bool) $visual_meta->get('status')->value);
     $this->assertEquals($audio_meta->get('field_volume')->value, 'low');
-    $this->assertNotTrue((bool) $audio_meta->get('status')->value);
+    $this->assertFalse((bool) $audio_meta->get('status')->value);
     $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-    $this->assertNotTrue((bool) $speed_meta->get('status')->value);
+    $this->assertFalse((bool) $speed_meta->get('status')->value);
 
     $this->assertCount(3, $this->entityMetaRelationStorage->loadMultiple());
     $this->assertCount(3, $this->entityMetaStorage->loadMultiple());
@@ -254,7 +254,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $node = $this->nodeStorage->load($node->id());
     /** @var \Drupal\emr\Entity\EntityMetaInterface $entity_meta */
     $entity_meta = $node->get('emr_entity_metas')->getEntityMeta('visual');
-    $this->assertTrue((bool) $entity_meta->isEnabled());
+    $this->assertTrue($entity_meta->isEnabled());
 
     // Load the node again to reset its meta list and create a new unpublished
     // revision.
@@ -269,7 +269,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $node = $this->nodeStorage->load($node->id());
     /** @var \Drupal\emr\Entity\EntityMetaInterface $entity_meta */
     $entity_meta = $node->get('emr_entity_metas')->getEntityMeta('visual');
-    $this->assertFalse((bool) $entity_meta->isEnabled());
+    $this->assertFalse($entity_meta->isEnabled());
   }
 
   /**

--- a/tests/Kernel/EntityMetaRelationRevisionTest.php
+++ b/tests/Kernel/EntityMetaRelationRevisionTest.php
@@ -52,7 +52,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
@@ -131,13 +131,13 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
 
     // Color has changed.
     $this->assertEquals($visual_meta->get('field_color')->value, 'blue');
-    $this->assertTrue($visual_meta->get('status')->value);
+    $this->assertTrue((boolean) $visual_meta->get('status')->value);
     // Audio is still as it was.
     $this->assertEquals($audio_meta->get('field_volume')->value, 'medium');
-    $this->assertTrue($audio_meta->get('status')->value);
+    $this->assertTrue((boolean) $audio_meta->get('status')->value);
     // Speed has changed as well.
     $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-    $this->assertTrue($speed_meta->get('status')->value);
+    $this->assertTrue((boolean) $speed_meta->get('status')->value);
 
     // One extra node revision exists now, so one extra relation and meta
     // revision should exist.
@@ -190,11 +190,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     // The meta values of the of the newly created node revisions should be the
     // same as the ones of the first revision.
     $this->assertEquals('red', $visual_meta->get('field_color')->value);
-    $this->assertFalse($visual_meta->get('status')->value);
+    $this->assertNotTrue((boolean) $visual_meta->get('status')->value);
     $this->assertEquals('low', $audio_meta->get('field_volume')->value);
-    $this->assertFalse($audio_meta->get('status')->value);
+    $this->assertNotTrue((boolean) $audio_meta->get('status')->value);
     $this->assertEquals('1', $speed_meta->getWrapper()->getGear());
-    $this->assertFalse($speed_meta->get('status')->value);
+    $this->assertNotTrue((boolean) $speed_meta->get('status')->value);
 
     // Change again a meta value and confirm everything is normal.
     $visual_meta->set('field_color', 'blue');
@@ -210,11 +210,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
 
     $this->assertEquals($visual_meta->get('field_color')->value, 'blue');
-    $this->assertFalse($visual_meta->get('status')->value);
+    $this->assertNotTrue((boolean) $visual_meta->get('status')->value);
     $this->assertEquals($audio_meta->get('field_volume')->value, 'low');
-    $this->assertFalse($audio_meta->get('status')->value);
+    $this->assertNotTrue((boolean) $audio_meta->get('status')->value);
     $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-    $this->assertFalse($speed_meta->get('status')->value);
+    $this->assertNotTrue((boolean) $speed_meta->get('status')->value);
 
     $this->assertCount(3, $this->entityMetaRelationStorage->loadMultiple());
     $this->assertCount(3, $this->entityMetaStorage->loadMultiple());
@@ -242,7 +242,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
       'type' => 'entity_meta_multi_example_ct',
       'title' => 'Node test',
     ]);
-    $node->setPublished(TRUE);
+    $node->setPublished();
     $entity_meta = $this->entityMetaStorage->create([
       'bundle' => 'visual',
       'field_color' => 'red',
@@ -254,13 +254,13 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $node = $this->nodeStorage->load($node->id());
     /** @var \Drupal\emr\Entity\EntityMetaInterface $entity_meta */
     $entity_meta = $node->get('emr_entity_metas')->getEntityMeta('visual');
-    $this->assertTrue($entity_meta->isEnabled());
+    $this->assertTrue((boolean) $entity_meta->isEnabled());
 
     // Load the node again to reset its meta list and create a new unpublished
     // revision.
     $this->nodeStorage->resetCache();
     $node = $this->nodeStorage->load($node->id());
-    $node->setPublished(FALSE);
+    $node->setUnpublished();
     $node->setNewRevision(TRUE);
     $node->save();
 
@@ -269,7 +269,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $node = $this->nodeStorage->load($node->id());
     /** @var \Drupal\emr\Entity\EntityMetaInterface $entity_meta */
     $entity_meta = $node->get('emr_entity_metas')->getEntityMeta('visual');
-    $this->assertFalse($entity_meta->isEnabled());
+    $this->assertFalse((boolean) $entity_meta->isEnabled());
   }
 
   /**
@@ -282,7 +282,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
       'title' => 'Node test',
       // We keep the node unpublished to test the meta respects the status.
     ]);
-    $node->setPublished(FALSE);
+    $node->setUnpublished();
 
     $entity_metas = [];
     $entity_metas[0] = $this->entityMetaStorage->create([
@@ -305,7 +305,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
 
     $node->setNewRevision(TRUE);
-    $node->setPublished(TRUE);
+    $node->setPublished();
 
     $audio_meta->getWrapper()->setVolume('medium');
     $speed_meta->getWrapper()->setGear('2');
@@ -324,7 +324,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $node->get('emr_entity_metas')->attach($entity_meta_visual);
     $node->get('emr_entity_metas')->attach($entity_meta_speed);
     $node->setNewRevision(TRUE);
-    $node->setPublished(FALSE);
+    $node->setUnpublished();
     $node->save();
 
     // Fourth revision - Change visual an publish back the node.
@@ -334,7 +334,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $entity_meta_visual->set('field_color', 'red');
     $node->get('emr_entity_metas')->attach($entity_meta_visual);
     $node->setNewRevision(TRUE);
-    $node->setPublished(TRUE);
+    $node->setPublished();
     $node->save();
 
     // Make the assertions for all the changes.
@@ -381,11 +381,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
         $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
 
         $this->assertEquals($visual_meta->get('field_color')->value, 'red');
-        $this->assertFalse($visual_meta->get('status')->value);
+        $this->assertFalse((boolean) $visual_meta->get('status')->value);
         $this->assertEquals($audio_meta->get('field_volume')->value, 'low');
-        $this->assertFalse($audio_meta->get('status')->value);
+        $this->assertFalse((boolean) $audio_meta->get('status')->value);
         $this->assertEquals($speed_meta->getWrapper()->getGear(), '1');
-        $this->assertFalse($speed_meta->get('status')->value);
+        $this->assertFalse((boolean) $speed_meta->get('status')->value);
         break;
 
       case 2:
@@ -396,11 +396,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
         $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
         // The visual meta was not changed but the other two were.
         $this->assertEquals($visual_meta->get('field_color')->value, 'red');
-        $this->assertTrue($visual_meta->get('status')->value);
+        $this->assertTrue((boolean) $visual_meta->get('status')->value);
         $this->assertEquals($audio_meta->get('field_volume')->value, 'medium');
-        $this->assertTrue($audio_meta->get('status')->value);
+        $this->assertTrue((boolean) $audio_meta->get('status')->value);
         $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-        $this->assertTrue($speed_meta->get('status')->value);
+        $this->assertTrue((boolean) $speed_meta->get('status')->value);
         break;
 
       case 3:
@@ -410,11 +410,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
         $visual_meta = $node->get('emr_entity_metas')->getEntityMeta('visual');
         $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
         $this->assertEquals($visual_meta->get('field_color')->value, 'green');
-        $this->assertFalse($visual_meta->get('status')->value);
+        $this->assertFalse((boolean) $visual_meta->get('status')->value);
         $this->assertEquals($audio_meta->get('field_volume')->value, 'medium');
-        $this->assertFalse($audio_meta->get('status')->value);
+        $this->assertFalse((boolean) $audio_meta->get('status')->value);
         $this->assertEquals($speed_meta->getWrapper()->getGear(), '3');
-        $this->assertFalse($speed_meta->get('status')->value);
+        $this->assertFalse((boolean) $speed_meta->get('status')->value);
         break;
 
       case 4:
@@ -423,11 +423,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
         $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
 
         $this->assertEquals($visual_meta->get('field_color')->value, 'red');
-        $this->assertTrue($visual_meta->get('status')->value);
+        $this->assertTrue((boolean) $visual_meta->get('status')->value);
         $this->assertEquals($audio_meta->get('field_volume')->value, 'medium');
-        $this->assertTrue($audio_meta->get('status')->value);
+        $this->assertTrue((boolean) $audio_meta->get('status')->value);
         $this->assertEquals($speed_meta->getWrapper()->getGear(), '3');
-        $this->assertTrue($speed_meta->get('status')->value);
+        $this->assertTrue((boolean) $speed_meta->get('status')->value);
         break;
     }
   }

--- a/tests/Kernel/EntityMetaRelationRevisionTest.php
+++ b/tests/Kernel/EntityMetaRelationRevisionTest.php
@@ -52,7 +52,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
@@ -131,13 +131,13 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
 
     // Color has changed.
     $this->assertEquals($visual_meta->get('field_color')->value, 'blue');
-    $this->assertTrue($visual_meta->get('status')->value);
+    $this->assertTrue((bool) $visual_meta->get('status')->value);
     // Audio is still as it was.
     $this->assertEquals($audio_meta->get('field_volume')->value, 'medium');
-    $this->assertTrue($audio_meta->get('status')->value);
+    $this->assertTrue((bool) $audio_meta->get('status')->value);
     // Speed has changed as well.
     $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-    $this->assertTrue($speed_meta->get('status')->value);
+    $this->assertTrue((bool) $speed_meta->get('status')->value);
 
     // One extra node revision exists now, so one extra relation and meta
     // revision should exist.
@@ -190,11 +190,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     // The meta values of the of the newly created node revisions should be the
     // same as the ones of the first revision.
     $this->assertEquals('red', $visual_meta->get('field_color')->value);
-    $this->assertFalse($visual_meta->get('status')->value);
+    $this->assertNotTrue((bool) $visual_meta->get('status')->value);
     $this->assertEquals('low', $audio_meta->get('field_volume')->value);
-    $this->assertFalse($audio_meta->get('status')->value);
+    $this->assertNotTrue((bool) $audio_meta->get('status')->value);
     $this->assertEquals('1', $speed_meta->getWrapper()->getGear());
-    $this->assertFalse($speed_meta->get('status')->value);
+    $this->assertNotTrue((bool) $speed_meta->get('status')->value);
 
     // Change again a meta value and confirm everything is normal.
     $visual_meta->set('field_color', 'blue');
@@ -210,11 +210,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
 
     $this->assertEquals($visual_meta->get('field_color')->value, 'blue');
-    $this->assertFalse($visual_meta->get('status')->value);
+    $this->assertNotTrue((bool) $visual_meta->get('status')->value);
     $this->assertEquals($audio_meta->get('field_volume')->value, 'low');
-    $this->assertFalse($audio_meta->get('status')->value);
+    $this->assertNotTrue((bool) $audio_meta->get('status')->value);
     $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-    $this->assertFalse($speed_meta->get('status')->value);
+    $this->assertNotTrue((bool) $speed_meta->get('status')->value);
 
     $this->assertCount(3, $this->entityMetaRelationStorage->loadMultiple());
     $this->assertCount(3, $this->entityMetaStorage->loadMultiple());
@@ -242,7 +242,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
       'type' => 'entity_meta_multi_example_ct',
       'title' => 'Node test',
     ]);
-    $node->setPublished(TRUE);
+    $node->setPublished();
     $entity_meta = $this->entityMetaStorage->create([
       'bundle' => 'visual',
       'field_color' => 'red',
@@ -254,13 +254,13 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $node = $this->nodeStorage->load($node->id());
     /** @var \Drupal\emr\Entity\EntityMetaInterface $entity_meta */
     $entity_meta = $node->get('emr_entity_metas')->getEntityMeta('visual');
-    $this->assertTrue($entity_meta->isEnabled());
+    $this->assertTrue((bool) $entity_meta->isEnabled());
 
     // Load the node again to reset its meta list and create a new unpublished
     // revision.
     $this->nodeStorage->resetCache();
     $node = $this->nodeStorage->load($node->id());
-    $node->setPublished(FALSE);
+    $node->setUnpublished();
     $node->setNewRevision(TRUE);
     $node->save();
 
@@ -269,7 +269,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $node = $this->nodeStorage->load($node->id());
     /** @var \Drupal\emr\Entity\EntityMetaInterface $entity_meta */
     $entity_meta = $node->get('emr_entity_metas')->getEntityMeta('visual');
-    $this->assertFalse($entity_meta->isEnabled());
+    $this->assertFalse((bool) $entity_meta->isEnabled());
   }
 
   /**
@@ -282,7 +282,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
       'title' => 'Node test',
       // We keep the node unpublished to test the meta respects the status.
     ]);
-    $node->setPublished(FALSE);
+    $node->setUnpublished();
 
     $entity_metas = [];
     $entity_metas[0] = $this->entityMetaStorage->create([
@@ -305,7 +305,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
 
     $node->setNewRevision(TRUE);
-    $node->setPublished(TRUE);
+    $node->setPublished();
 
     $audio_meta->getWrapper()->setVolume('medium');
     $speed_meta->getWrapper()->setGear('2');
@@ -324,7 +324,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $node->get('emr_entity_metas')->attach($entity_meta_visual);
     $node->get('emr_entity_metas')->attach($entity_meta_speed);
     $node->setNewRevision(TRUE);
-    $node->setPublished(FALSE);
+    $node->setUnpublished();
     $node->save();
 
     // Fourth revision - Change visual an publish back the node.
@@ -334,7 +334,7 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
     $entity_meta_visual->set('field_color', 'red');
     $node->get('emr_entity_metas')->attach($entity_meta_visual);
     $node->setNewRevision(TRUE);
-    $node->setPublished(TRUE);
+    $node->setPublished();
     $node->save();
 
     // Make the assertions for all the changes.
@@ -381,11 +381,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
         $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
 
         $this->assertEquals($visual_meta->get('field_color')->value, 'red');
-        $this->assertFalse($visual_meta->get('status')->value);
+        $this->assertFalse((bool) $visual_meta->get('status')->value);
         $this->assertEquals($audio_meta->get('field_volume')->value, 'low');
-        $this->assertFalse($audio_meta->get('status')->value);
+        $this->assertFalse((bool) $audio_meta->get('status')->value);
         $this->assertEquals($speed_meta->getWrapper()->getGear(), '1');
-        $this->assertFalse($speed_meta->get('status')->value);
+        $this->assertFalse((bool) $speed_meta->get('status')->value);
         break;
 
       case 2:
@@ -396,11 +396,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
         $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
         // The visual meta was not changed but the other two were.
         $this->assertEquals($visual_meta->get('field_color')->value, 'red');
-        $this->assertTrue($visual_meta->get('status')->value);
+        $this->assertTrue((bool) $visual_meta->get('status')->value);
         $this->assertEquals($audio_meta->get('field_volume')->value, 'medium');
-        $this->assertTrue($audio_meta->get('status')->value);
+        $this->assertTrue((bool) $audio_meta->get('status')->value);
         $this->assertEquals($speed_meta->getWrapper()->getGear(), '2');
-        $this->assertTrue($speed_meta->get('status')->value);
+        $this->assertTrue((bool) $speed_meta->get('status')->value);
         break;
 
       case 3:
@@ -410,11 +410,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
         $visual_meta = $node->get('emr_entity_metas')->getEntityMeta('visual');
         $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
         $this->assertEquals($visual_meta->get('field_color')->value, 'green');
-        $this->assertFalse($visual_meta->get('status')->value);
+        $this->assertFalse((bool) $visual_meta->get('status')->value);
         $this->assertEquals($audio_meta->get('field_volume')->value, 'medium');
-        $this->assertFalse($audio_meta->get('status')->value);
+        $this->assertFalse((bool) $audio_meta->get('status')->value);
         $this->assertEquals($speed_meta->getWrapper()->getGear(), '3');
-        $this->assertFalse($speed_meta->get('status')->value);
+        $this->assertFalse((bool) $speed_meta->get('status')->value);
         break;
 
       case 4:
@@ -423,11 +423,11 @@ class EntityMetaRelationRevisionTest extends KernelTestBase {
         $speed_meta = $node->get('emr_entity_metas')->getEntityMeta('speed');
 
         $this->assertEquals($visual_meta->get('field_color')->value, 'red');
-        $this->assertTrue($visual_meta->get('status')->value);
+        $this->assertTrue((bool) $visual_meta->get('status')->value);
         $this->assertEquals($audio_meta->get('field_volume')->value, 'medium');
-        $this->assertTrue($audio_meta->get('status')->value);
+        $this->assertTrue((bool) $audio_meta->get('status')->value);
         $this->assertEquals($speed_meta->getWrapper()->getGear(), '3');
-        $this->assertTrue($speed_meta->get('status')->value);
+        $this->assertTrue((bool) $speed_meta->get('status')->value);
         break;
     }
   }

--- a/tests/Kernel/EntityMetaRelationTest.php
+++ b/tests/Kernel/EntityMetaRelationTest.php
@@ -458,7 +458,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertEmpty($this->entityMetaStorage->loadMultiple());
 
     $entity_meta_speed = $this->getEntityMetaList($node)->getEntityMeta('speed');
-    $this->assertTrue((bool) $entity_meta_speed->isNew());
+    $this->assertTrue($entity_meta_speed->isNew());
     $entity_meta_speed->getWrapper()->setGear(1);
 
     /** @var \Drupal\emr\Entity\EntityMetaInterface $entity_meta */
@@ -618,7 +618,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertCount(3, $relation_revisions);
     $this->assertEquals([2, 4, 6], array_keys($relation_revisions));
     $revision = $this->entityMetaRelationStorage->loadRevision(6);
-    $this->assertTrue((bool) $revision->isDefaultRevision());
+    $this->assertTrue($revision->isDefaultRevision());
     // There are 4 entity meta revisions, two for each meta.
     $this->assertCount(4, $this->entityMetaStorage->getQuery()->allRevisions()->execute());
 
@@ -637,7 +637,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertCount(1, $relation_revisions);
     $this->assertEquals([2], array_keys($relation_revisions));
     $revision = $this->entityMetaRelationStorage->loadRevision(2);
-    $this->assertTrue((bool) $revision->isDefaultRevision());
+    $this->assertTrue($revision->isDefaultRevision());
     // One of the entity meta revisions became orphaned so it should have been
     // deleted.
     $this->assertCount(3, $this->entityMetaStorage->getQuery()->allRevisions()->execute());
@@ -652,7 +652,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertCount(1, $related_entity_meta_entities);
     $this->assertEquals('3', $entity_meta_speed->getWrapper()->getGear());
     // Since the audio meta was detached, it should be returned as a new entity.
-    $this->assertTrue((bool) $entity_meta_audio->isNew());
+    $this->assertTrue($entity_meta_audio->isNew());
 
     // We detached the audio meta from the latest revision of the node, but
     // we should still see it attached on the first.
@@ -737,7 +737,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $related_entity_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertCount(1, $related_entity_meta_entities);
     $this->assertEquals('3', $entity_meta_speed->getWrapper()->getGear());
-    $this->assertTrue((bool) $entity_meta_audio->isNew());
+    $this->assertTrue($entity_meta_audio->isNew());
 
     // Detach second entity meta.
     $node->setNewRevision(TRUE);
@@ -753,8 +753,8 @@ class EntityMetaRelationTest extends KernelTestBase {
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
     $related_entity_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertCount(0, $related_entity_meta_entities);
-    $this->assertTrue((bool) $entity_meta_speed->isNew());
-    $this->assertTrue((bool) $entity_meta_audio->isNew());
+    $this->assertTrue($entity_meta_speed->isNew());
+    $this->assertTrue($entity_meta_audio->isNew());
 
     // The previous node revisions should still have the same related metas.
     $node = $this->nodeStorage->loadRevision(5);
@@ -763,7 +763,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $related_entity_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertCount(1, $related_entity_meta_entities);
     $this->assertEquals('3', $entity_meta_speed->getWrapper()->getGear());
-    $this->assertTrue((bool) $entity_meta_audio->isNew());
+    $this->assertTrue($entity_meta_audio->isNew());
   }
 
   /**
@@ -835,7 +835,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $related_entity_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertCount(1, $related_entity_meta_entities);
     $this->assertEquals($entity_meta_speed->getWrapper()->getGear(), '3');
-    $this->assertTrue((bool) $entity_meta_audio->isNew());
+    $this->assertTrue($entity_meta_audio->isNew());
   }
 
   /**
@@ -935,10 +935,10 @@ class EntityMetaRelationTest extends KernelTestBase {
     ]);
     $node->save();
     $this->assertEquals(2, $node->getRevisionId());
-    $this->assertTrue((bool) $node->isDefaultRevision());
+    $this->assertTrue($node->isDefaultRevision());
 
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
-    $this->assertTrue((bool) $entity_meta_audio->isNew());
+    $this->assertTrue($entity_meta_audio->isNew());
     $entity_meta_audio->getWrapper()->setVolume('low');
 
     $this->getEntityMetaList($node)->attach($entity_meta_audio);
@@ -961,7 +961,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->entityMetaStorage->resetCache();
     $node = $this->nodeStorage->load(2);
     $this->assertEquals(3, $node->getRevisionId());
-    $this->assertTrue((bool) $node->isDefaultRevision());
+    $this->assertTrue($node->isDefaultRevision());
     $entity_meta_audio = $this->entityMetaStorage->load(1);
     $this->assertEquals(2, $entity_meta_audio->getRevisionId());
     $this->assertEquals('medium', $entity_meta_audio->get('field_volume')->value);
@@ -980,9 +980,9 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->entityMetaStorage->resetCache();
     $node = $this->nodeStorage->load(2);
     $this->assertEquals(4, $node->getRevisionId());
-    $this->assertTrue((bool) $node->isDefaultRevision());
+    $this->assertTrue($node->isDefaultRevision());
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
-    $this->assertTrue((bool) $entity_meta_audio->isNew());
+    $this->assertTrue($entity_meta_audio->isNew());
     // Since the default revision of the node no longer is linked to the meta,
     // there is no more default meta revision so no metas should be found.
     $this->assertNull($this->entityMetaStorage->load(1));
@@ -993,7 +993,7 @@ class EntityMetaRelationTest extends KernelTestBase {
 
     // Attach back the audio meta.
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
-    $this->assertTrue((bool) $entity_meta_audio->isNew());
+    $this->assertTrue($entity_meta_audio->isNew());
     $entity_meta_audio->getWrapper()->setVolume('high');
     $this->getEntityMetaList($node)->attach($entity_meta_audio);
     $node->setNewRevision(TRUE);
@@ -1003,7 +1003,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->entityMetaStorage->resetCache();
     $node = $this->nodeStorage->load(2);
     $this->assertEquals(5, $node->getRevisionId());
-    $this->assertTrue((bool) $node->isDefaultRevision());
+    $this->assertTrue($node->isDefaultRevision());
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
     $this->assertEquals(3, $entity_meta_audio->getRevisionId());
 
@@ -1022,7 +1022,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->entityMetaStorage->resetCache();
     $node = $this->nodeStorage->load(2);
     $this->assertEquals(6, $node->getRevisionId());
-    $this->assertTrue((bool) $node->isDefaultRevision());
+    $this->assertTrue($node->isDefaultRevision());
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
     $this->assertEquals(4, $entity_meta_audio->getRevisionId());
     $this->assertEquals(2, $entity_meta_audio->id());
@@ -1039,7 +1039,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     // No new node revision.
     $this->assertEquals(6, $node->getRevisionId());
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
-    $this->assertTrue((bool) $entity_meta_audio->isNew());
+    $this->assertTrue($entity_meta_audio->isNew());
 
     // The last meta revision was deleted because the relation to it was deleted
     // so it became orphan.

--- a/tests/Kernel/EntityMetaRelationTest.php
+++ b/tests/Kernel/EntityMetaRelationTest.php
@@ -55,7 +55,7 @@ class EntityMetaRelationTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
@@ -458,7 +458,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertEmpty($this->entityMetaStorage->loadMultiple());
 
     $entity_meta_speed = $this->getEntityMetaList($node)->getEntityMeta('speed');
-    $this->assertTrue($entity_meta_speed->isNew());
+    $this->assertTrue((bool) $entity_meta_speed->isNew());
     $entity_meta_speed->getWrapper()->setGear(1);
 
     /** @var \Drupal\emr\Entity\EntityMetaInterface $entity_meta */
@@ -618,7 +618,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertCount(3, $relation_revisions);
     $this->assertEquals([2, 4, 6], array_keys($relation_revisions));
     $revision = $this->entityMetaRelationStorage->loadRevision(6);
-    $this->assertTrue($revision->isDefaultRevision());
+    $this->assertTrue((bool) $revision->isDefaultRevision());
     // There are 4 entity meta revisions, two for each meta.
     $this->assertCount(4, $this->entityMetaStorage->getQuery()->allRevisions()->execute());
 
@@ -637,7 +637,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertCount(1, $relation_revisions);
     $this->assertEquals([2], array_keys($relation_revisions));
     $revision = $this->entityMetaRelationStorage->loadRevision(2);
-    $this->assertTrue($revision->isDefaultRevision());
+    $this->assertTrue((bool) $revision->isDefaultRevision());
     // One of the entity meta revisions became orphaned so it should have been
     // deleted.
     $this->assertCount(3, $this->entityMetaStorage->getQuery()->allRevisions()->execute());
@@ -652,7 +652,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertCount(1, $related_entity_meta_entities);
     $this->assertEquals('3', $entity_meta_speed->getWrapper()->getGear());
     // Since the audio meta was detached, it should be returned as a new entity.
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((bool) $entity_meta_audio->isNew());
 
     // We detached the audio meta from the latest revision of the node, but
     // we should still see it attached on the first.
@@ -737,7 +737,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $related_entity_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertCount(1, $related_entity_meta_entities);
     $this->assertEquals('3', $entity_meta_speed->getWrapper()->getGear());
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((bool) $entity_meta_audio->isNew());
 
     // Detach second entity meta.
     $node->setNewRevision(TRUE);
@@ -753,8 +753,8 @@ class EntityMetaRelationTest extends KernelTestBase {
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
     $related_entity_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertCount(0, $related_entity_meta_entities);
-    $this->assertTrue($entity_meta_speed->isNew());
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((bool) $entity_meta_speed->isNew());
+    $this->assertTrue((bool) $entity_meta_audio->isNew());
 
     // The previous node revisions should still have the same related metas.
     $node = $this->nodeStorage->loadRevision(5);
@@ -763,7 +763,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $related_entity_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertCount(1, $related_entity_meta_entities);
     $this->assertEquals('3', $entity_meta_speed->getWrapper()->getGear());
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((bool) $entity_meta_audio->isNew());
   }
 
   /**
@@ -835,7 +835,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $related_entity_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertCount(1, $related_entity_meta_entities);
     $this->assertEquals($entity_meta_speed->getWrapper()->getGear(), '3');
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((bool) $entity_meta_audio->isNew());
   }
 
   /**
@@ -935,10 +935,10 @@ class EntityMetaRelationTest extends KernelTestBase {
     ]);
     $node->save();
     $this->assertEquals(2, $node->getRevisionId());
-    $this->assertTrue(2, $node->isDefaultRevision());
+    $this->assertTrue((bool) $node->isDefaultRevision());
 
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((bool) $entity_meta_audio->isNew());
     $entity_meta_audio->getWrapper()->setVolume('low');
 
     $this->getEntityMetaList($node)->attach($entity_meta_audio);
@@ -961,7 +961,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->entityMetaStorage->resetCache();
     $node = $this->nodeStorage->load(2);
     $this->assertEquals(3, $node->getRevisionId());
-    $this->assertTrue($node->isDefaultRevision());
+    $this->assertTrue((bool) $node->isDefaultRevision());
     $entity_meta_audio = $this->entityMetaStorage->load(1);
     $this->assertEquals(2, $entity_meta_audio->getRevisionId());
     $this->assertEquals('medium', $entity_meta_audio->get('field_volume')->value);
@@ -980,9 +980,9 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->entityMetaStorage->resetCache();
     $node = $this->nodeStorage->load(2);
     $this->assertEquals(4, $node->getRevisionId());
-    $this->assertTrue($node->isDefaultRevision());
+    $this->assertTrue((bool) $node->isDefaultRevision());
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((bool) $entity_meta_audio->isNew());
     // Since the default revision of the node no longer is linked to the meta,
     // there is no more default meta revision so no metas should be found.
     $this->assertNull($this->entityMetaStorage->load(1));
@@ -993,7 +993,7 @@ class EntityMetaRelationTest extends KernelTestBase {
 
     // Attach back the audio meta.
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((bool) $entity_meta_audio->isNew());
     $entity_meta_audio->getWrapper()->setVolume('high');
     $this->getEntityMetaList($node)->attach($entity_meta_audio);
     $node->setNewRevision(TRUE);
@@ -1003,7 +1003,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->entityMetaStorage->resetCache();
     $node = $this->nodeStorage->load(2);
     $this->assertEquals(5, $node->getRevisionId());
-    $this->assertTrue($node->isDefaultRevision());
+    $this->assertTrue((bool) $node->isDefaultRevision());
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
     $this->assertEquals(3, $entity_meta_audio->getRevisionId());
 
@@ -1022,7 +1022,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->entityMetaStorage->resetCache();
     $node = $this->nodeStorage->load(2);
     $this->assertEquals(6, $node->getRevisionId());
-    $this->assertTrue($node->isDefaultRevision());
+    $this->assertTrue((bool) $node->isDefaultRevision());
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
     $this->assertEquals(4, $entity_meta_audio->getRevisionId());
     $this->assertEquals(2, $entity_meta_audio->id());
@@ -1039,7 +1039,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     // No new node revision.
     $this->assertEquals(6, $node->getRevisionId());
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((bool) $entity_meta_audio->isNew());
 
     // The last meta revision was deleted because the relation to it was deleted
     // so it became orphan.
@@ -1064,39 +1064,39 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertNull($entity_meta->get('emr_default_revision')->value);
     $entity_meta->save();
     // When the entity meta is created, the first revision is marked as default.
-    $this->assertTrue($entity_meta->get('emr_default_revision')->value);
+    $this->assertTrue((bool) $entity_meta->get('emr_default_revision')->value);
     $this->entityMetaStorage->resetCache();
     $entity_meta = $this->entityMetaStorage->load($entity_meta->id());
-    $this->assertTrue($entity_meta->get('emr_default_revision')->value);
+    $this->assertTrue((bool) $entity_meta->get('emr_default_revision')->value);
     $this->assertDefaultEntityMetaRevision($entity_meta, 1);
 
     // Make a new revision and mark it as default.
     $entity_meta->setNewRevision(TRUE);
     $entity_meta->set('emr_default_revision', TRUE);
-    $this->assertTrue($entity_meta->get('emr_default_revision')->value);
+    $this->assertTrue((bool) $entity_meta->get('emr_default_revision')->value);
     $this->assertDefaultEntityMetaRevision($entity_meta, 1);
     $entity_meta->save();
     $this->entityMetaStorage->resetCache();
     $entity_meta = $this->entityMetaStorage->load($entity_meta->id());
-    $this->assertTrue($entity_meta->get('emr_default_revision')->value);
+    $this->assertTrue((bool) $entity_meta->get('emr_default_revision')->value);
     $this->assertDefaultEntityMetaRevision($entity_meta, 2);
 
     // Load the first revision and assert it's not marked as default.
     $revision = $this->entityMetaStorage->loadRevision(1);
-    $this->assertFalse($revision->get('emr_default_revision')->value);
+    $this->assertFalse((bool) $revision->get('emr_default_revision')->value);
 
     // Mark back the first revision as the default.
     $revision->set('emr_default_revision', TRUE);
-    $this->assertTrue($revision->get('emr_default_revision')->value);
+    $this->assertTrue((bool) $revision->get('emr_default_revision')->value);
     // The tracking table is not yet updated.
     $this->assertDefaultEntityMetaRevision($entity_meta, 2);
     $revision->save();
     $this->entityMetaStorage->resetCache();
     $revision = $this->entityMetaStorage->loadRevision(1);
-    $this->assertTrue($revision->get('emr_default_revision')->value);
+    $this->assertTrue((bool) $revision->get('emr_default_revision')->value);
     $this->assertDefaultEntityMetaRevision($entity_meta, 1);
     $entity_meta = $this->entityMetaStorage->loadRevision(2);
-    $this->assertFalse($entity_meta->get('emr_default_revision')->value);
+    $this->assertFalse((bool) $entity_meta->get('emr_default_revision')->value);
 
     // Mark the first revision to not be default either (none are left default).
     $revision->set('emr_default_revision', FALSE);
@@ -1105,7 +1105,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertNull($this->entityMetaStorage->load(1));
     foreach ([1, 2] as $revision_id) {
       $revision = $this->entityMetaStorage->loadRevision($revision_id);
-      $this->assertFalse($revision->get('emr_default_revision')->value);
+      $this->assertFalse((bool) $revision->get('emr_default_revision')->value);
     }
     $this->assertNoDefaultEntityMetaRevision(1);
   }

--- a/tests/Kernel/EntityMetaRelationTest.php
+++ b/tests/Kernel/EntityMetaRelationTest.php
@@ -55,7 +55,7 @@ class EntityMetaRelationTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
@@ -458,7 +458,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertEmpty($this->entityMetaStorage->loadMultiple());
 
     $entity_meta_speed = $this->getEntityMetaList($node)->getEntityMeta('speed');
-    $this->assertTrue($entity_meta_speed->isNew());
+    $this->assertTrue((boolean) $entity_meta_speed->isNew());
     $entity_meta_speed->getWrapper()->setGear(1);
 
     /** @var \Drupal\emr\Entity\EntityMetaInterface $entity_meta */
@@ -618,7 +618,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertCount(3, $relation_revisions);
     $this->assertEquals([2, 4, 6], array_keys($relation_revisions));
     $revision = $this->entityMetaRelationStorage->loadRevision(6);
-    $this->assertTrue($revision->isDefaultRevision());
+    $this->assertTrue((boolean) $revision->isDefaultRevision());
     // There are 4 entity meta revisions, two for each meta.
     $this->assertCount(4, $this->entityMetaStorage->getQuery()->allRevisions()->execute());
 
@@ -637,7 +637,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertCount(1, $relation_revisions);
     $this->assertEquals([2], array_keys($relation_revisions));
     $revision = $this->entityMetaRelationStorage->loadRevision(2);
-    $this->assertTrue($revision->isDefaultRevision());
+    $this->assertTrue((boolean) $revision->isDefaultRevision());
     // One of the entity meta revisions became orphaned so it should have been
     // deleted.
     $this->assertCount(3, $this->entityMetaStorage->getQuery()->allRevisions()->execute());
@@ -652,7 +652,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertCount(1, $related_entity_meta_entities);
     $this->assertEquals('3', $entity_meta_speed->getWrapper()->getGear());
     // Since the audio meta was detached, it should be returned as a new entity.
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((boolean) $entity_meta_audio->isNew());
 
     // We detached the audio meta from the latest revision of the node, but
     // we should still see it attached on the first.
@@ -737,7 +737,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $related_entity_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertCount(1, $related_entity_meta_entities);
     $this->assertEquals('3', $entity_meta_speed->getWrapper()->getGear());
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((boolean) $entity_meta_audio->isNew());
 
     // Detach second entity meta.
     $node->setNewRevision(TRUE);
@@ -753,8 +753,8 @@ class EntityMetaRelationTest extends KernelTestBase {
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
     $related_entity_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertCount(0, $related_entity_meta_entities);
-    $this->assertTrue($entity_meta_speed->isNew());
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((boolean) $entity_meta_speed->isNew());
+    $this->assertTrue((boolean) $entity_meta_audio->isNew());
 
     // The previous node revisions should still have the same related metas.
     $node = $this->nodeStorage->loadRevision(5);
@@ -763,7 +763,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $related_entity_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertCount(1, $related_entity_meta_entities);
     $this->assertEquals('3', $entity_meta_speed->getWrapper()->getGear());
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((boolean) $entity_meta_audio->isNew());
   }
 
   /**
@@ -835,7 +835,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $related_entity_meta_entities = $this->entityMetaStorage->getRelatedEntities($node);
     $this->assertCount(1, $related_entity_meta_entities);
     $this->assertEquals($entity_meta_speed->getWrapper()->getGear(), '3');
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((boolean) $entity_meta_audio->isNew());
   }
 
   /**
@@ -935,10 +935,10 @@ class EntityMetaRelationTest extends KernelTestBase {
     ]);
     $node->save();
     $this->assertEquals(2, $node->getRevisionId());
-    $this->assertTrue(2, $node->isDefaultRevision());
+    $this->assertTrue((boolean) $node->isDefaultRevision());
 
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((boolean) $entity_meta_audio->isNew());
     $entity_meta_audio->getWrapper()->setVolume('low');
 
     $this->getEntityMetaList($node)->attach($entity_meta_audio);
@@ -961,7 +961,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->entityMetaStorage->resetCache();
     $node = $this->nodeStorage->load(2);
     $this->assertEquals(3, $node->getRevisionId());
-    $this->assertTrue($node->isDefaultRevision());
+    $this->assertTrue((boolean) $node->isDefaultRevision());
     $entity_meta_audio = $this->entityMetaStorage->load(1);
     $this->assertEquals(2, $entity_meta_audio->getRevisionId());
     $this->assertEquals('medium', $entity_meta_audio->get('field_volume')->value);
@@ -980,9 +980,9 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->entityMetaStorage->resetCache();
     $node = $this->nodeStorage->load(2);
     $this->assertEquals(4, $node->getRevisionId());
-    $this->assertTrue($node->isDefaultRevision());
+    $this->assertTrue((boolean) $node->isDefaultRevision());
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((boolean) $entity_meta_audio->isNew());
     // Since the default revision of the node no longer is linked to the meta,
     // there is no more default meta revision so no metas should be found.
     $this->assertNull($this->entityMetaStorage->load(1));
@@ -993,7 +993,7 @@ class EntityMetaRelationTest extends KernelTestBase {
 
     // Attach back the audio meta.
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((boolean) $entity_meta_audio->isNew());
     $entity_meta_audio->getWrapper()->setVolume('high');
     $this->getEntityMetaList($node)->attach($entity_meta_audio);
     $node->setNewRevision(TRUE);
@@ -1003,7 +1003,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->entityMetaStorage->resetCache();
     $node = $this->nodeStorage->load(2);
     $this->assertEquals(5, $node->getRevisionId());
-    $this->assertTrue($node->isDefaultRevision());
+    $this->assertTrue((boolean) $node->isDefaultRevision());
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
     $this->assertEquals(3, $entity_meta_audio->getRevisionId());
 
@@ -1022,7 +1022,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->entityMetaStorage->resetCache();
     $node = $this->nodeStorage->load(2);
     $this->assertEquals(6, $node->getRevisionId());
-    $this->assertTrue($node->isDefaultRevision());
+    $this->assertTrue((boolean) $node->isDefaultRevision());
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
     $this->assertEquals(4, $entity_meta_audio->getRevisionId());
     $this->assertEquals(2, $entity_meta_audio->id());
@@ -1039,7 +1039,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     // No new node revision.
     $this->assertEquals(6, $node->getRevisionId());
     $entity_meta_audio = $this->getEntityMetaList($node)->getEntityMeta('audio');
-    $this->assertTrue($entity_meta_audio->isNew());
+    $this->assertTrue((boolean) $entity_meta_audio->isNew());
 
     // The last meta revision was deleted because the relation to it was deleted
     // so it became orphan.
@@ -1064,39 +1064,39 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertNull($entity_meta->get('emr_default_revision')->value);
     $entity_meta->save();
     // When the entity meta is created, the first revision is marked as default.
-    $this->assertTrue($entity_meta->get('emr_default_revision')->value);
+    $this->assertTrue((boolean) $entity_meta->get('emr_default_revision')->value);
     $this->entityMetaStorage->resetCache();
     $entity_meta = $this->entityMetaStorage->load($entity_meta->id());
-    $this->assertTrue($entity_meta->get('emr_default_revision')->value);
+    $this->assertTrue((boolean) $entity_meta->get('emr_default_revision')->value);
     $this->assertDefaultEntityMetaRevision($entity_meta, 1);
 
     // Make a new revision and mark it as default.
     $entity_meta->setNewRevision(TRUE);
     $entity_meta->set('emr_default_revision', TRUE);
-    $this->assertTrue($entity_meta->get('emr_default_revision')->value);
+    $this->assertTrue((boolean) $entity_meta->get('emr_default_revision')->value);
     $this->assertDefaultEntityMetaRevision($entity_meta, 1);
     $entity_meta->save();
     $this->entityMetaStorage->resetCache();
     $entity_meta = $this->entityMetaStorage->load($entity_meta->id());
-    $this->assertTrue($entity_meta->get('emr_default_revision')->value);
+    $this->assertTrue((boolean) $entity_meta->get('emr_default_revision')->value);
     $this->assertDefaultEntityMetaRevision($entity_meta, 2);
 
     // Load the first revision and assert it's not marked as default.
     $revision = $this->entityMetaStorage->loadRevision(1);
-    $this->assertFalse($revision->get('emr_default_revision')->value);
+    $this->assertFalse((boolean) $revision->get('emr_default_revision')->value);
 
     // Mark back the first revision as the default.
     $revision->set('emr_default_revision', TRUE);
-    $this->assertTrue($revision->get('emr_default_revision')->value);
+    $this->assertTrue((boolean) $revision->get('emr_default_revision')->value);
     // The tracking table is not yet updated.
     $this->assertDefaultEntityMetaRevision($entity_meta, 2);
     $revision->save();
     $this->entityMetaStorage->resetCache();
     $revision = $this->entityMetaStorage->loadRevision(1);
-    $this->assertTrue($revision->get('emr_default_revision')->value);
+    $this->assertTrue((boolean) $revision->get('emr_default_revision')->value);
     $this->assertDefaultEntityMetaRevision($entity_meta, 1);
     $entity_meta = $this->entityMetaStorage->loadRevision(2);
-    $this->assertFalse($entity_meta->get('emr_default_revision')->value);
+    $this->assertFalse((boolean) $entity_meta->get('emr_default_revision')->value);
 
     // Mark the first revision to not be default either (none are left default).
     $revision->set('emr_default_revision', FALSE);
@@ -1105,7 +1105,7 @@ class EntityMetaRelationTest extends KernelTestBase {
     $this->assertNull($this->entityMetaStorage->load(1));
     foreach ([1, 2] as $revision_id) {
       $revision = $this->entityMetaStorage->loadRevision($revision_id);
-      $this->assertFalse($revision->get('emr_default_revision')->value);
+      $this->assertFalse((boolean) $revision->get('emr_default_revision')->value);
     }
     $this->assertNoDefaultEntityMetaRevision(1);
   }


### PR DESCRIPTION
## OPENEUROPA-OEL-77

### Description

Fix Drupal 9 compatibility issues.

### Change log

- Added:
- Changed: update all module files to specify that the module is compatible with drupal 9
- Deprecated: replace deprecated link function with toLink
- Removed:
- Fixed:
- Security:

